### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/planecq/planecq.com.png?label=ready&title=Ready)](https://waffle.io/planecq/planecq.com)
 [![Build Status](https://travis-ci.org/planecq/planecq.com.svg?branch=master)](https://travis-ci.org/planecq/planecq.com)
 # planecq.com
 Planecq Landing Page


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/planecq/planecq.com

This was requested by a real person (user tibotiber) on waffle.io, we're not trying to spam you.
